### PR TITLE
Fix a forgotten "key" prop for a map

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ export const AnsiComponent: React.FC<AnsiComponentProps> = ({
   return (
     <Text style={containerStyle}>
       {parsedAnsi.map((item: Anser.AnserJsonEntry) => (
-        <Text style={applyStyle(item, textStyle)}>{item.content}</Text>
+        <Text style={applyStyle(item, textStyle)} key={parsedAnsi.indexOf(item)}>{item.content}</Text>
       ))}
     </Text>
   );


### PR DESCRIPTION
Added a key prop that caused errors for apps ("Each element should have a unique key prop")